### PR TITLE
Fix nav title and add research overview

### DIFF
--- a/about.html
+++ b/about.html
@@ -12,7 +12,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Welcome</a></li>
-                <li><a href="research.html">Research direction</a></li>
+                <li><a href="research.html">Research directions</a></li>
                 <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>

--- a/contact.html
+++ b/contact.html
@@ -12,7 +12,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Welcome</a></li>
-                <li><a href="research.html">Research direction</a></li>
+                <li><a href="research.html">Research directions</a></li>
                 <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Welcome</a></li>
-                <li><a href="research.html">Research direction</a></li>
+                <li><a href="research.html">Research directions</a></li>
                 <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>

--- a/publications.html
+++ b/publications.html
@@ -12,7 +12,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Welcome</a></li>
-                <li><a href="research.html">Research direction</a></li>
+                <li><a href="research.html">Research directions</a></li>
                 <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>

--- a/research.html
+++ b/research.html
@@ -3,16 +3,16 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Research direction - PhD Scientist</title>
+    <title>Research directions - PhD Scientist</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
     <header>
-        <h1>Research direction</h1>
+        <h1>Research directions</h1>
         <nav>
             <ul>
                 <li><a href="index.html">Welcome</a></li>
-                <li><a href="research.html">Research direction</a></li>
+                <li><a href="research.html">Research directions</a></li>
                 <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
@@ -27,10 +27,22 @@
             </ul>
         </nav>
 
+        <section id="overview">
+            <h2>Overview</h2>
+            <p>This page introduces our main research directions:
+                <a href="#hypergraphs">Hypergraphs</a>,
+                <a href="#complex">Complex networks in data analysis</a> and
+                <a href="#game">Game theory on networks</a>.
+                Follow the links to jump to each section.</p>
+        </section>
+
         <section id="hypergraphs">
             <h2>Hypergraphs</h2>
             <div class="project-box">
-                <p>This is a test project description for hypergraphs.</p>
+                <h3>Hypergraph Community Detection</h3>
+                <p>We develop algorithms that extend modularity optimisation to
+                uncover communities in data where relationships involve more
+                than two nodes.</p>
             </div>
         </section>
 

--- a/teaching.html
+++ b/teaching.html
@@ -12,7 +12,7 @@
         <nav>
             <ul>
                 <li><a href="index.html">Welcome</a></li>
-                <li><a href="research.html">Research direction</a></li>
+                <li><a href="research.html">Research directions</a></li>
                 <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>


### PR DESCRIPTION
## Summary
- rename Research direction navigation links to Research directions everywhere
- add an overview paragraph on the research page
- describe a hypergraph project in its own box

## Testing
- `python3 test.py`

------
https://chatgpt.com/codex/tasks/task_e_688503d8a2a08323b49df90406af6629