### PR TITLE
Remove teaching tab and add Russian research page

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,6 @@
             <ul>
                 <li><a href="index.html">Welcome</a></li>
                 <li><a href="research.html">Research directions</a></li>
-                <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/contact.html
+++ b/contact.html
@@ -13,7 +13,6 @@
             <ul>
                 <li><a href="index.html">Welcome</a></li>
                 <li><a href="research.html">Research directions</a></li>
-                <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
             <ul>
                 <li><a href="index.html">Welcome</a></li>
                 <li><a href="research.html">Research directions</a></li>
-                <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/publications.html
+++ b/publications.html
@@ -13,7 +13,6 @@
             <ul>
                 <li><a href="index.html">Welcome</a></li>
                 <li><a href="research.html">Research directions</a></li>
-                <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/research.html
+++ b/research.html
@@ -13,7 +13,6 @@
             <ul>
                 <li><a href="index.html">Welcome</a></li>
                 <li><a href="research.html">Research directions</a></li>
-                <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
         </nav>

--- a/research_rus.html
+++ b/research_rus.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ru">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Направления исследований - PhD Scientist</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <header>
+        <h1>Направления исследований</h1>
+        <nav>
+            <ul>
+                <li><a href="index.html">Welcome</a></li>
+                <li><a href="research.html">Research directions</a></li>
+                <li><a href="contact.html">Contact</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section id="overview">
+            <h2>Обзор</h2>
+            <p>Эта страница представляет основные направления исследований:</p>
+            <ul>
+                <li><a href="#hypergraphs">Гиперграфы</a></li>
+                <li><a href="#complex">Сложные сети в анализе данных</a></li>
+                <li><a href="#game">Теория игр на сетях</a></li>
+            </ul>
+        </section>
+        <section id="hypergraphs">
+            <h2>Гиперграфы</h2>
+            <div class="project-box">
+                <p>Мы разрабатываем алгоритмы для обнаружения сообществ в данных, где связи могут объединять более двух узлов.</p>
+            </div>
+        </section>
+        <hr class="section-divider">
+        <section id="complex">
+            <h2>Сложные сети в анализе данных</h2>
+            <div class="project-box">
+                <p>Описание проекта для сложных сетей.</p>
+            </div>
+        </section>
+        <hr class="section-divider">
+        <section id="game">
+            <h2>Теория игр на сетях</h2>
+            <div class="project-box">
+                <p>Описание проекта для теории игр на сетях.</p>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2023 Dr. Science Example</p>
+    </footer>
+</body>
+</html>

--- a/teaching.html
+++ b/teaching.html
@@ -13,7 +13,6 @@
             <ul>
                 <li><a href="index.html">Welcome</a></li>
                 <li><a href="research.html">Research directions</a></li>
-                <li><a href="teaching.html">Teaching</a></li>
                 <li><a href="contact.html">Contact</a></li>
             </ul>
         </nav>


### PR DESCRIPTION
## Summary
- remove Teaching tab from all navigation bars
- add a Russian-language research page that links to the rest of the site
- keep the Teaching page accessible only by direct URL

## Testing
- `python3 test.py`

------
https://chatgpt.com/codex/tasks/task_e_68861f52b04883239e51a499debc1b26